### PR TITLE
Add basic CSS IntelliSense

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to TS Server",
+      "type": "node",
+      "request": "launch",
+      "protocol": "inspector",
+      "port": 9222,
+      "sourceMaps": true,
+      "outFiles": ["./lib"],
+      "stopOnEntry": true,
+      "runtimeArgs": [
+          "--inspect-brk=5999" //an open port
+        ]
+      }
+  ]
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -2,6 +2,7 @@
   "name": "e2e",
   "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "typescript": {
       "version": "2.4.2",

--- a/e2e/tests/completionEntryDetails.js
+++ b/e2e/tests/completionEntryDetails.js
@@ -5,7 +5,7 @@ const { openMockFile, getFirstResponseOfType } = require('./_helpers');
 const mockFileName = 'main.ts';
 
 describe('CompletionEntryDetails', () => {
-    it('should return details for tag completion', () => {
+    it('should return html details for tag completion', () => {
         const server = createServer();
         openMockFile(server, mockFileName, 'const q = html`<`');
         server.send({ command: 'completionEntryDetails', arguments: { file: mockFileName, offset: 17, line: 1, entryNames: ['a'] } });
@@ -18,6 +18,22 @@ describe('CompletionEntryDetails', () => {
             const firstDetails = completionsResponse.body[0]
             assert.strictEqual(firstDetails.name, 'a');
             assert.isTrue(firstDetails.documentation[0].text.indexOf('href') >= 0, 'documentation has href');
+        });
+    });
+
+    it('should return css details for tag completion', () => {
+        const server = createServer();
+        openMockFile(server, mockFileName, 'const q = html`<style> .test {  }</style>`');
+        server.send({ command: 'completionEntryDetails', arguments: { file: mockFileName, offset: 32, line: 1, entryNames: ['color'] } });
+
+        return server.close().then(() => {
+            const completionsResponse = getFirstResponseOfType('completionEntryDetails', server);
+            assert.isTrue(completionsResponse.success);
+            assert.strictEqual(completionsResponse.body.length, 1);
+
+            const firstDetails = completionsResponse.body[0]
+            assert.strictEqual(firstDetails.name, 'color');
+            assert.isTrue(firstDetails.documentation[0].text.indexOf('color') >= 0, 'documentation has color');
         });
     });
 });

--- a/e2e/tests/completions.js
+++ b/e2e/tests/completions.js
@@ -4,8 +4,8 @@ const { openMockFile, getFirstResponseOfType } = require('./_helpers');
 
 const mockFileName = 'main.ts';
 
-describe('Completions', () => {
-    it('should return tag completions for html tag', () => {
+describe('HTML Completions', () => {
+    it('should return html tag completions for html tag', () => {
         return makeSingleCompletionsRequest(
             'const q = html`<`',
             { offset: 17, line: 1 }
@@ -15,7 +15,7 @@ describe('Completions', () => {
         });
     });
 
-    it('should return tag completions for raw tag', () => {
+    it('should return html tag completions for raw tag', () => {
         return makeSingleCompletionsRequest(
             'const q = raw`<`',
             { offset: 16, line: 1 }
@@ -24,7 +24,7 @@ describe('Completions', () => {
         });
     });
 
-    it('should return property completions', () => {
+    it('should return html property completions', () => {
         return makeSingleCompletionsRequest(
             'const q = html`<button `',
             { line: 1, offset: 24 }
@@ -33,7 +33,95 @@ describe('Completions', () => {
             assert.isTrue(completionsResponse.body.some(item => item.name === 'title'));
         });
     });
-})
+
+    it('should not return html completions for html tag inside of <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = html`<style> .test {  }</style>`',
+            { offset: 32, line: 1 }
+        ).then(completionsResponse => {
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'div'));
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'main'));
+        });
+    });
+
+    it('should not return html completions for raw tag inside of <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = raw`<style> .test {  }</style>`',
+            { offset: 31, line: 1 }
+        ).then(completionsResponse => {
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'div'));
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'main'));
+        });
+    });
+});
+
+describe('CSS Completions', () => {
+    it('should return css completions for html tag within <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = html`<style> .test {  }</style>`',
+            { offset: 32, line: 1 }
+        ).then(completionsResponse => {
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'display'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'position'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'color'));
+        });
+    });
+
+    it('should return css completions for raw tag within <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = raw`<style> .test {  }</style>`',
+            { offset: 31, line: 1 }
+        ).then(completionsResponse => {
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'display'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'position'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'color'));
+        });
+    });
+
+    it('should return css property completions for html tag within <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = html`<style> .test { display:  }</style>`',
+            { offset: 40, line: 1 }
+        ).then(completionsResponse => {
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'block'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'flex'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'grid'));
+        });
+    });
+
+    it('should return css property completions for raw tag within <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = raw`<style> .test { display:  }</style>`',
+            { offset: 39, line: 1 }
+        ).then(completionsResponse => {
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'block'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'flex'));
+            assert.isTrue(completionsResponse.body.some(item => item.name === 'grid'));
+        });
+    });
+
+    it('should not return css completions for html tag outside of <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = html` `',
+            { offset: 16, line: 1 }
+        ).then(completionsResponse => {
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'display'));
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'position'));
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'color'));
+        });
+    });
+
+    it('should not return css completions for raw tag outside of <style>', () => {
+        return makeSingleCompletionsRequest(
+            'const q = raw` `',
+            { offset: 15, line: 1 }
+        ).then(completionsResponse => {
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'display'));
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'position'));
+            assert.isFalse(completionsResponse.body.some(item => item.name === 'color'));
+        });
+    });
+});
 
 function makeSingleCompletionsRequest(body, position) {
     const server = createServer();

--- a/e2e/tests/embeddedSupport.js
+++ b/e2e/tests/embeddedSupport.js
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// Derived from https://github.com/Microsoft/vscode/blob/master/extensions/html-language-features/server/src/test/embedded.test.ts
+
+const assert = require('chai').assert;
+const test = require('mocha').test;
+const embeddedSupport = require('../../lib/embeddedSupport')
+const vscodeTypes = require('vscode-languageserver-types');
+const vscodeHtmlService = require('vscode-html-languageservice');
+
+describe('Embedded Language Identification', () => {
+    test('<style>', function () {
+        assertLanguageId('const q = html`|<html><style>foo { }</style></html>`', 'html');
+        assertLanguageId('const q = html`<html|><style>foo { }</style></html>`', 'html');
+        assertLanguageId('const q = html`<html><st|yle>foo { }</style></html>`', 'html');
+        assertLanguageId('const q = html`<html><style>|foo { }</style></html>`', 'css');
+        assertLanguageId('const q = html`<html><style>foo| { }</style></html>`', 'css');
+        assertLanguageId('const q = html`<html><style>foo { }|</style></html>`', 'css');
+        assertLanguageId('const q = html`<html><style>foo { }</sty|le></html>`', 'html');
+    });
+
+    test('<style> - Incomplete HTML', function () {
+        assertLanguageId('const q = html`|<html><style>foo { }`', 'html');
+        assertLanguageId('const q = html`<html><style>fo|o { }`', 'css');
+        assertLanguageId('const q = html`<html><style>foo { }|`', 'css');
+    });
+
+    test('CSS in HTML attributes', function () {
+        assertLanguageId('const q = html`<div id="xy" |style="color: red"/>`', 'html');
+        assertLanguageId('const q = html`<div id="xy" styl|e="color: red"/>`', 'html');
+        assertLanguageId('const q = html`<div id="xy" style=|"color: red"/>`', 'html');
+        assertLanguageId('const q = html`<div id="xy" style="|color: red"/>`', 'css');
+        assertLanguageId('const q = html`<div id="xy" style="color|: red"/>`', 'css');
+        assertLanguageId('const q = html`<div id="xy" style="color: red|"/>`', 'css');
+        assertLanguageId('const q = html`<div id="xy" style="color: red"|/>`', 'html');
+        assertLanguageId('const q = html`<div id="xy" style=\'color: r|ed\'/>`', 'css');
+        assertLanguageId('const q = html`<div id="xy" style|=color:red/>`', 'html');
+        assertLanguageId('const q = html`<div id="xy" style=|color:red/>`', 'css');
+        assertLanguageId('const q = html`<div id="xy" style=color:r|ed/>`', 'css');
+        assertLanguageId('const q = html`<div id="xy" style=color:red|/>`', 'css');
+        assertLanguageId('const q = html`<div id="xy" style=color:red/|>`', 'html');
+    });
+});
+
+const htmlLanguageService = vscodeHtmlService.getLanguageService();
+
+function assertLanguageId(value, expectedLanguageId) {
+    let offset = value.indexOf('|');
+    value = value.substr(0, offset) + value.substr(offset + 1);
+
+    let document = vscodeTypes.TextDocument.create('test://test/test.html', 'html', 0, value);
+
+    let position = document.positionAt(offset);
+
+    let docRegions = embeddedSupport.getDocumentRegions(htmlLanguageService, document);
+    let languageId = docRegions.getLanguageAtPosition(position);
+
+    assert.equal(languageId, expectedLanguageId);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-lit-html-plugin",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -539,24 +539,40 @@
       "dev": true
     },
     "typescript-template-language-service-decorator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-1.1.0.tgz",
-      "integrity": "sha512-+mALyEIQTMskZJErim4wG60tBWmXwk1lyuWqZk5K1/pDC8KmmJdyeJo0Gye49cSY4P7xSsJzARuL481rnwqvbg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-1.2.0.tgz",
+      "integrity": "sha512-rF0jrvpYn6Ec2jnxBHF1st/HEl84LV7od8872o82zHgKEU1vFhT4x6fvuLi5UD0gl2gKv3zSefG18DoeUHE7ig=="
+    },
+    "vscode-css-languageservice": {
+      "version": "3.0.9-next.19",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.9-next.19.tgz",
+      "integrity": "sha512-ezY3E3JnXZ0pVtMtpz8Vvsk1hX5uw7yNxA9gaGF5Lg3cggoKPQlJbp7/RC0vtWzOhZfK3V3vTBUVR84c6JI+cg==",
+      "requires": {
+        "vscode-languageserver-types": "3.8.2",
+        "vscode-nls": "3.2.2"
+      },
+      "dependencies": {
+        "vscode-nls": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.2.tgz",
+          "integrity": "sha512-/Ur1+tgazwd51+ncRyoy0UIu4dvMdVXS9XMUULQlZIBoNGEwOhwEx9x+hHWoUjldMrOQ32t2CGKo0u6D4R6/hg=="
+        }
+      }
     },
     "vscode-html-languageservice": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-2.0.10.tgz",
       "integrity": "sha1-odT4vVDRBgpGJUTsOIOAqmrcgjU=",
       "requires": {
-        "vscode-languageserver-types": "3.4.0",
+        "vscode-languageserver-types": "3.8.2",
         "vscode-nls": "2.0.2",
         "vscode-uri": "1.0.1"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.4.0.tgz",
-      "integrity": "sha1-UEOuR+5KwWrwe7PQylYSNeDA0vo="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.2.tgz",
+      "integrity": "sha512-2RMkyt1O1czGPCnkjKZWSio2D8oh3XlQ4zi4W2xL8q2Dvi4hB3/DEt+wYyzo4hmE2ZFP0RB8PXyzHyed7p1hbw=="
     },
     "vscode-nls": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "url": "https://github.com/Microsoft/typescript-lit-html-plugin/issues"
   },
   "dependencies": {
-    "typescript-template-language-service-decorator": "^1.1.0",
+    "typescript-template-language-service-decorator": "^1.2.0",
+    "vscode-css-languageservice": "^3.0.9-next.19",
     "vscode-html-languageservice": "^2.0.10",
-    "vscode-languageserver-types": "^3.4.0"
+    "vscode-languageserver-types": "^3.8.2"
   },
   "files": [
     "lib"

--- a/src/embeddedSupport.ts
+++ b/src/embeddedSupport.ts
@@ -1,0 +1,328 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// Original code forked from https://github.com/vscode-langservers/vscode-html-languageserver/
+
+'use strict';
+
+import {
+    TextDocument,
+    Position,
+    LanguageService,
+    TokenType,
+    Range
+} from 'vscode-html-languageservice';
+
+export interface LanguageRange extends Range {
+    languageId: string | undefined;
+    attributeValue?: boolean;
+}
+
+export interface HTMLDocumentRegions {
+    getEmbeddedDocument(
+        languageId: string,
+        ignoreAttributeValues?: boolean
+    ): TextDocument;
+    getLanguageAtPosition(position: Position): string | undefined;
+}
+
+export const CSS_STYLE_RULE = '__';
+
+interface EmbeddedRegion {
+    languageId: string | undefined;
+    start: number;
+    end: number;
+    attributeValue?: boolean;
+}
+
+export function getDocumentRegions(
+    languageService: LanguageService,
+    document: TextDocument
+): HTMLDocumentRegions {
+    const regions: EmbeddedRegion[] = [];
+    const scanner = languageService.createScanner(document.getText());
+    let lastTagName: string = '';
+    let lastAttributeName: string | null = null;
+    let languageIdFromType: string | undefined;
+    const importedScripts: string[] = [];
+
+    let token = scanner.scan();
+    while (token !== TokenType.EOS) {
+        switch (token) {
+            case TokenType.StartTag:
+                lastTagName = scanner.getTokenText();
+                lastAttributeName = null;
+                languageIdFromType = 'javascript';
+                break;
+            case TokenType.Styles:
+                regions.push({
+                    languageId: 'css',
+                    start: scanner.getTokenOffset(),
+                    end: scanner.getTokenEnd(),
+                });
+                break;
+            case TokenType.Script:
+                regions.push({
+                    languageId: languageIdFromType,
+                    start: scanner.getTokenOffset(),
+                    end: scanner.getTokenEnd(),
+                });
+                break;
+            case TokenType.AttributeName:
+                lastAttributeName = scanner.getTokenText();
+                break;
+            case TokenType.AttributeValue:
+                if (
+                    lastAttributeName === 'src' &&
+                    lastTagName.toLowerCase() === 'script'
+                ) {
+                    let value = scanner.getTokenText();
+                    if (value[0] === '\'' || value[0] === '"') {
+                        value = value.substr(1, value.length - 1);
+                    }
+                    importedScripts.push(value);
+                } else if (
+                    lastAttributeName === 'type' &&
+                    lastTagName.toLowerCase() === 'script'
+                ) {
+                    if (
+                        /["'](module|(text|application)\/(java|ecma)script)["']/.test(
+                            scanner.getTokenText()
+                        )
+                    ) {
+                        languageIdFromType = 'javascript';
+                    } else {
+                        languageIdFromType = void 0;
+                    }
+                } else {
+                    const attributeLanguageId = getAttributeLanguage(
+                        lastAttributeName!
+                    );
+                    if (attributeLanguageId) {
+                        let start = scanner.getTokenOffset();
+                        let end = scanner.getTokenEnd();
+                        const firstChar = document.getText()[start];
+                        if (firstChar === '\'' || firstChar === '"') {
+                            start++;
+                            end--;
+                        }
+                        regions.push({
+                            languageId: attributeLanguageId,
+                            start,
+                            end,
+                            attributeValue: true,
+                        });
+                    }
+                }
+                lastAttributeName = null;
+                break;
+        }
+        token = scanner.scan();
+    }
+    return {
+        getEmbeddedDocument: (
+            languageId: string,
+            ignoreAttributeValues: boolean
+        ) =>
+            getEmbeddedDocument(
+                document,
+                regions,
+                languageId,
+                ignoreAttributeValues
+            ),
+        getLanguageAtPosition: (position: Position) =>
+            getLanguageAtPosition(document, regions, position),
+    };
+}
+
+function getLanguageRanges(
+    document: TextDocument,
+    regions: EmbeddedRegion[],
+    range: Range
+): LanguageRange[] {
+    const result: LanguageRange[] = [];
+    let currentPos = range ? range.start : Position.create(0, 0);
+    let currentOffset = range ? document.offsetAt(range.start) : 0;
+    const endOffset = range
+        ? document.offsetAt(range.end)
+        : document.getText().length;
+    for (const region of regions) {
+        if (region.end > currentOffset && region.start < endOffset) {
+            const start = Math.max(region.start, currentOffset);
+            const startPos = document.positionAt(start);
+            if (currentOffset < region.start) {
+                result.push({
+                    start: currentPos,
+                    end: startPos,
+                    languageId: 'html',
+                });
+            }
+            const end = Math.min(region.end, endOffset);
+            const endPos = document.positionAt(end);
+            if (end > region.start) {
+                result.push({
+                    start: startPos,
+                    end: endPos,
+                    languageId: region.languageId,
+                    attributeValue: region.attributeValue,
+                });
+            }
+            currentOffset = end;
+            currentPos = endPos;
+        }
+    }
+    if (currentOffset < endOffset) {
+        const endPos = range ? range.end : document.positionAt(endOffset);
+        result.push({
+            start: currentPos,
+            end: endPos,
+            languageId: 'html',
+        });
+    }
+    return result;
+}
+
+function getLanguagesInDocument(
+    document: TextDocument,
+    regions: EmbeddedRegion[]
+): string[] {
+    const result = [];
+    for (const region of regions) {
+        if (region.languageId && result.indexOf(region.languageId) === -1) {
+            result.push(region.languageId);
+            if (result.length === 3) {
+                return result;
+            }
+        }
+    }
+    result.push('html');
+    return result;
+}
+
+function getLanguageAtPosition(
+    document: TextDocument,
+    regions: EmbeddedRegion[],
+    position: Position
+): string | undefined {
+    const offset = document.offsetAt(position);
+    for (const region of regions) {
+        if (region.start <= offset) {
+            if (offset <= region.end) {
+                return region.languageId;
+            }
+        } else {
+            break;
+        }
+    }
+    return 'html';
+}
+
+function getEmbeddedDocument(
+    document: TextDocument,
+    contents: EmbeddedRegion[],
+    languageId: string,
+    ignoreAttributeValues: boolean
+): TextDocument {
+    let currentPos = 0;
+    const oldContent = document.getText();
+    let result = '';
+    let lastSuffix = '';
+    for (const c of contents) {
+        if (
+            c.languageId === languageId &&
+            (!ignoreAttributeValues || !c.attributeValue)
+        ) {
+            result = substituteWithWhitespace(
+                result,
+                currentPos,
+                c.start,
+                oldContent,
+                lastSuffix,
+                getPrefix(c)
+            );
+            result += oldContent.substring(c.start, c.end);
+            currentPos = c.end;
+            lastSuffix = getSuffix(c);
+        }
+    }
+    result = substituteWithWhitespace(
+        result,
+        currentPos,
+        oldContent.length,
+        oldContent,
+        lastSuffix,
+        ''
+    );
+    return TextDocument.create(
+        document.uri,
+        languageId,
+        document.version,
+        result
+    );
+}
+
+function getPrefix(c: EmbeddedRegion) {
+    if (c.attributeValue) {
+        switch (c.languageId) {
+            case 'css':
+                return CSS_STYLE_RULE + '{';
+        }
+    }
+    return '';
+}
+function getSuffix(c: EmbeddedRegion) {
+    if (c.attributeValue) {
+        switch (c.languageId) {
+            case 'css':
+                return '}';
+            case 'javascript':
+                return ';';
+        }
+    }
+    return '';
+}
+
+function substituteWithWhitespace(
+    result: string,
+    start: number,
+    end: number,
+    oldContent: string,
+    before: string,
+    after: string
+) {
+    let accumulatedWS = 0;
+    result += before;
+    for (let i = start + before.length; i < end; i++) {
+        const ch = oldContent[i];
+        if (ch === '\n' || ch === '\r') {
+            // only write new lines, skip the whitespace
+            accumulatedWS = 0;
+            result += ch;
+        } else {
+            accumulatedWS++;
+        }
+    }
+    result = append(result, ' ', accumulatedWS - after.length);
+    result += after;
+    return result;
+}
+
+function append(result: string, str: string, n: number): string {
+    while (n > 0) {
+        if (n & 1) {
+            result += str;
+        }
+        n >>= 1;
+        str += str;
+    }
+    return result;
+}
+
+function getAttributeLanguage(attributeName: string): string | null {
+    const match = attributeName.match(/^(style)$|^(on\w+)$/i);
+    if (!match) {
+        return null;
+    }
+    return match[1] ? 'css' : 'javascript';
+}

--- a/src/html-template-language-service.ts
+++ b/src/html-template-language-service.ts
@@ -254,7 +254,7 @@ export default class HtmlTemplateLanguageService implements TemplateLanguageServ
 
         const completions: vscode.CompletionList = {
             isIncomplete: false,
-            items: [...completionsCss.items, ...completionsHtml.items],
+            items: [...completionsHtml.items, ...completionsCss.items],
         };
 
         this._completionsCache.updateCached(context, position, completions);
@@ -371,6 +371,7 @@ function translateionCompletionItemKind(
             return typescript.ScriptElementKind.unknown;
     }
 }
+
 
 function toDisplayParts(
     text: string | vscode.MarkupContent | undefined

--- a/src/html-template-language-service.ts
+++ b/src/html-template-language-service.ts
@@ -4,9 +4,9 @@
 // Original code forked from https://github.com/Quramy/ts-graphql-plugin
 
 import * as ts from 'typescript/lib/tsserverlibrary';
-import { getLanguageService, LanguageService } from 'vscode-html-languageservice';
+import { getLanguageService, LanguageService as htmlLanguageService } from 'vscode-html-languageservice';
+import { getCSSLanguageService, LanguageService as cssLanguageService } from 'vscode-css-languageservice';
 import * as vscode from 'vscode-languageserver-types';
-import * as config from './config';
 import { TsHtmlPluginConfiguration } from './configuration';
 import { TemplateLanguageService, TemplateContext, Logger } from 'typescript-template-language-service-decorator';
 
@@ -16,6 +16,11 @@ function arePositionsEqual(
 ): boolean {
     return left.line === right.line && left.character === right.character;
 }
+
+const emptyCompletionList: vscode.CompletionList = {
+    isIncomplete: false,
+    items: [],
+};
 
 class CompletionsCache {
     private _cachedCompletionsFile?: string;
@@ -51,7 +56,8 @@ class CompletionsCache {
 }
 
 export default class HtmlTemplateLanguageService implements TemplateLanguageService {
-    private _htmlLanguageService?: LanguageService;
+    private _htmlLanguageService?: htmlLanguageService;
+    private _cssLanguageService?: cssLanguageService;
     private _completionsCache = new CompletionsCache();
 
     constructor(
@@ -60,11 +66,18 @@ export default class HtmlTemplateLanguageService implements TemplateLanguageServ
         private readonly logger: Logger
     ) { }
 
-    private get htmlLanguageService(): LanguageService {
+    private get htmlLanguageService(): htmlLanguageService {
         if (!this._htmlLanguageService) {
             this._htmlLanguageService = getLanguageService();
         }
         return this._htmlLanguageService;
+    }
+
+    private get cssLanguageService(): cssLanguageService {
+        if (!this._cssLanguageService) {
+            this._cssLanguageService = getCSSLanguageService();
+        }
+        return this._cssLanguageService;
     }
 
     public getCompletionsAtPosition(
@@ -203,6 +216,25 @@ export default class HtmlTemplateLanguageService implements TemplateLanguageServ
         };
     }
 
+    private createCssVirtualDocument(
+        context: TemplateContext
+    ): vscode.TextDocument {
+        const contents = context.text;
+        return {
+            uri: 'untitled://embedded.css',
+            languageId: 'css',
+            version: 1,
+            getText: () => contents,
+            positionAt: (offset: number) => {
+                return context.toPosition(offset);
+            },
+            offsetAt: (p: vscode.Position) => {
+                return context.toOffset(p);
+            },
+            lineCount: contents.split(/n/g).length + 1,
+        };
+    }
+
     private getCompletionItems(
         context: TemplateContext,
         position: ts.LineAndCharacter
@@ -212,11 +244,21 @@ export default class HtmlTemplateLanguageService implements TemplateLanguageServ
             return cached;
         }
 
-        const doc = this.createVirtualDocument(context);
-        const htmlDoc = this.htmlLanguageService.parseHTMLDocument(doc);
-        const completions = this.htmlLanguageService.doComplete(doc, position, htmlDoc);
+        const cssDoc = this.createCssVirtualDocument(context);
+        const stylesheet = this.cssLanguageService.parseStylesheet(cssDoc);
+        const completionsCss = this.cssLanguageService.doComplete(cssDoc, position, stylesheet) || emptyCompletionList;
+
+        const htmlDoc = this.createVirtualDocument(context);
+        const html = this.htmlLanguageService.parseHTMLDocument(htmlDoc);
+        const completionsHtml = this.htmlLanguageService.doComplete(htmlDoc, position, html) || emptyCompletionList;
+
+        const completions: vscode.CompletionList = {
+            isIncomplete: false,
+            items: [...completionsCss.items, ...completionsHtml.items],
+        };
+
         this._completionsCache.updateCached(context, position, completions);
-        return this.htmlLanguageService.doComplete(doc, position, htmlDoc);
+        return completions;
     }
 
     private translateHover(
@@ -331,7 +373,13 @@ function translateionCompletionItemKind(
 }
 
 function toDisplayParts(
-    text: string | undefined
+    text: string | vscode.MarkupContent | undefined
 ): ts.SymbolDisplayPart[] {
-    return text ? [{ text, kind: 'text' }] : [];
+    if (!text) {
+        return [];
+    }
+    return [{
+        kind: 'text',
+        text: typeof text === 'string' ? text : text.value,
+    }];
 }

--- a/src/html-template-language-service.ts
+++ b/src/html-template-language-service.ts
@@ -380,7 +380,6 @@ function translateionCompletionItemKind(
     }
 }
 
-
 function toDisplayParts(
     text: string | vscode.MarkupContent | undefined
 ): ts.SymbolDisplayPart[] {


### PR DESCRIPTION
This PR adds what I would consider a basic level of support for CSS intellisense within `html` and `raw` (#8 and https://github.com/mjbvz/vscode-lit-html/issues/29)

1. Completion of CSS properties works properly.
2. Completion of CSS property values works properly.
3. Everything else previously works the same (HTML and Typescript/JS var completion).

What this PR doesn't do at the moment:
1. CSS error diagnostics for mistyped props/values (which I think will take a bit more effort to get right and should be done separately)
2. ~~Doesn't scope the CSS completion list to `<style>` (I could think of some lit-html approaches that may not have `<style>`, so it's pretty loose here in an attempt to make the developer experience better on the whole).~~ Fixed in 0ecb6c3

I'm happy to make changes if this isn't the proper approach or if y'all would like this a different way. I couldn't find a lot of best practices for the approach to this (though I did look through [Microsoft/typescript-template-language-service-decorator](https://github.com/Microsoft/typescript-template-language-service-decorator) to try to get a grasp).

![image](https://user-images.githubusercontent.com/643503/42063031-b15d3b26-7ae4-11e8-852e-9c4d93355ec1.png)
![image](https://user-images.githubusercontent.com/643503/42063034-b44a844c-7ae4-11e8-9470-34a73a66e133.png)
