### PR TITLE
Add quickfix support for embedded css blocks

### DIFF
--- a/e2e/tests/quickfix.js
+++ b/e2e/tests/quickfix.js
@@ -1,0 +1,73 @@
+// @ts-check
+const assert = require('chai').assert;
+const path = require('path');
+const createServer = require('../server-fixture');
+const { openMockFile, getFirstResponseOfType } = require('./_helpers');
+
+const mockFileName = path.join(__dirname, '..', 'project-fixture', 'main.ts');
+
+describe('QuickFix', () => {
+    it('should return css quickfix for misspelled properties', async () => {
+        const quickFix = await getQuickFixInMockFile([
+            'const q = html`',
+            '<style>',
+            'a { coloor: green; }',
+            '</style>',
+            '`'
+        ].join('\n'), {
+            startLine: 3,
+            startOffset: 8,
+            endLine: 3,
+            endOffset: 8,
+            errorCodes: [9999]
+        });
+        assert.strictEqual(quickFix.length, 3);
+        assert.isOk(quickFix.find(fix => fix.description === 'Rename to \'color\''));
+    });
+
+    it('should not return css quickfix for correctly spelled properties', async () => {
+        const quickFix = await getQuickFixInMockFile([
+            'const q = html`',
+            '<style>',
+            'a { color: green; }',
+            '</style>',
+            '`'
+        ].join('\n'), {
+            startLine: 3,
+            startOffset: 8,
+            endLine: 3,
+            endOffset: 8,
+            errorCodes: [9999]
+        });
+        assert.strictEqual(quickFix.length, 0);
+    });
+
+    it('should not return css quickfix outside of <style>', async () => {
+        const quickFix = await getQuickFixInMockFile([
+            'const q = html`',
+            '<style>',
+            'a { color: green; }',
+            '</style>',
+            '<h1>coloor</h1>',
+            '`'
+        ].join('\n'), {
+            startLine: 4,
+            startOffset: 8,
+            endLine: 4,
+            endOffset: 8,
+            errorCodes: [9999]
+        });
+        assert.strictEqual(quickFix.length, 0);
+    });
+});
+
+function getQuickFixInMockFile(contents, position) {
+    const server = createServer();
+    openMockFile(server, mockFileName, contents);
+
+    server.sendCommand('getCodeFixes', { file: mockFileName, ...position });
+    return server.close().then(() => {
+        const test = getFirstResponseOfType('getCodeFixes', server);
+        return test.body;
+    });
+}


### PR DESCRIPTION
This PR adds quickfix support for the css within `<style>`. The approach is similar to the styled plugin, but instead of running `doValidation` on the entire document, it uses the `getEmbeddedDocument('css')` to only return the CSS portion so that the validation doesn't run on html tags and report incorrectly.

I've added three additional tests to validate the new behavior. The gif below is representative, though I did change the diagnostic source name to `pluginName` as opposed to the :fire: emoji. :-)

![output](https://user-images.githubusercontent.com/643503/42396455-8decf5ae-8116-11e8-848d-84f95952953f.gif)
